### PR TITLE
Add dashboard redirect after login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="mysql://USER:PASSWORD@localhost:3306/pgsdn"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-"# PGSDN" 
+# PGSDN
+
+Este proyecto contiene un ejemplo de aplicación Next.js con un backend en Python
+para realizar configuraciones SDN. La base de datos utilizada es MySQL a través de
+Prisma ORM. Incluye un simple sistema de registro e inicio de sesión. Luego de
+autenticarse exitosamente el usuario es redirigido a la página `/dashboard`.
+
+## Instalación
+
+1. Copie `.env.example` a `.env` y actualice las credenciales de la base de datos.
+2. Instale las dependencias de Node:
+   ```bash
+   npm install
+   ```
+3. Ejecute las migraciones y genere el cliente Prisma:
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+4. Inicie la aplicación:
+   ```bash
+   npm run dev
+   ```
+
+## Python SDN
+
+El directorio `sdn/` contiene un script de ejemplo `controller.py` donde se
+podría implementar la lógica para gestionar configuraciones en equipos de red.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pgsdn",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@prisma/client": "5.11.1",
+    "prisma": "5.11.1",
+    "bcryptjs": "2.4.3"
+  }
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,29 @@
+import { PrismaClient } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método no permitido' })
+  }
+  const { email, password } = req.body
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Faltan datos' })
+  }
+  try {
+    const user = await prisma.user.findUnique({ where: { email } })
+    if (!user) {
+      return res.status(400).json({ error: 'Credenciales inválidas' })
+    }
+    const valid = await bcrypt.compare(password, user.password)
+    if (!valid) {
+      return res.status(400).json({ error: 'Credenciales inválidas' })
+    }
+    return res.status(200).json({ ok: true })
+  } catch (err) {
+    return res.status(500).json({ error: 'Error en el servidor' })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/pages/api/register.js
+++ b/pages/api/register.js
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método no permitido' })
+  }
+  const { name, email, password } = req.body
+  if (!name || !email || !password) {
+    return res.status(400).json({ error: 'Faltan datos' })
+  }
+  try {
+    const existing = await prisma.user.findUnique({ where: { email } })
+    if (existing) {
+      return res.status(400).json({ error: 'El correo ya existe' })
+    }
+    const hashed = await bcrypt.hash(password, 10)
+    await prisma.user.create({ data: { name, email, password: hashed } })
+    return res.status(200).json({ ok: true })
+  } catch (err) {
+    return res.status(500).json({ error: 'Error en el servidor' })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,8 @@
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>Bienvenido al panel principal</p>
+    </div>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Bienvenido a PGSDN</h1>
+      <p><a href="/register">Registrarse</a> o <a href="/login">Ingresar</a></p>
+    </div>
+  )
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Login() {
+  const router = useRouter()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    if (res.ok) {
+      router.push('/dashboard')
+    } else {
+      const data = await res.json()
+      setError(data.error)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Ingresar</h1>
+      <form onSubmit={handleSubmit}>
+        <input name="email" type="email" placeholder="Correo" onChange={handleChange} />
+        <input name="password" type="password" placeholder="Contraseña" onChange={handleChange} />
+        <button type="submit">Entrar</button>
+      </form>
+      {error && <p style={{color:'red'}}>{error}</p>}
+    </div>
+  )
+}

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Register() {
+  const router = useRouter()
+  const [form, setForm] = useState({ name: '', email: '', password: '' })
+  const [error, setError] = useState('')
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      const data = await res.json()
+      setError(data.error)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Registrarse</h1>
+      <form onSubmit={handleSubmit}>
+        <input name="name" placeholder="Nombre" onChange={handleChange} />
+        <input name="email" type="email" placeholder="Correo" onChange={handleChange} />
+        <input name="password" type="password" placeholder="Contraseña" onChange={handleChange} />
+        <button type="submit">Crear cuenta</button>
+      </form>
+      {error && <p style={{color:'red'}}>{error}</p>}
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,18 @@
+// Prisma schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String
+  password  String
+  createdAt DateTime @default(now())
+}

--- a/sdn/controller.py
+++ b/sdn/controller.py
@@ -1,0 +1,14 @@
+"""Controlador SDN de ejemplo."""
+import os
+
+
+def apply_config(device_ip: str, config: str):
+    """Aplica una configuracion al equipo. Funcion de ejemplo."""
+    print(f"Aplicando configuracion a {device_ip}: {config}")
+    # Aqui se podria usar paramiko/netmiko para enviar la configuracion
+    # a un equipo de red. Este codigo es solo ilustrativo.
+
+
+if __name__ == "__main__":
+    ip = os.environ.get("DEVICE_IP", "10.0.0.1")
+    apply_config(ip, "hostname SDN")


### PR DESCRIPTION
## Summary
- add `/dashboard` page
- redirect to `/dashboard` after successful login
- document redirect behavior in README

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6867e0d38c8c83229e92bf6d516db76b